### PR TITLE
Reduce precision of values in Ganglia writer to respect C constraints

### DIFF
--- a/src/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformer.java
+++ b/src/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformer.java
@@ -1,0 +1,23 @@
+package com.googlecode.jmxtrans.model.results;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+
+public class CPrecisionValueTransformer implements ValueTransformer {
+
+	private static final BigDecimal C_PRECISION = new BigDecimal("1E-308");
+
+	@Nullable
+	@Override
+	public Object apply(Object input) {
+		if (input == null) return null;
+		if (!Number.class.isAssignableFrom(input.getClass())) return input;
+
+		BigDecimal inputNumber = new BigDecimal(input.toString());
+
+		if (inputNumber.abs().compareTo(C_PRECISION) < 0) return 0;
+
+		return input;
+	}
+
+}

--- a/test/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformerTests.java
+++ b/test/com/googlecode/jmxtrans/model/results/CPrecisionValueTransformerTests.java
@@ -1,0 +1,49 @@
+package com.googlecode.jmxtrans.model.results;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CPrecisionValueTransformerTests {
+
+	@Test
+	public void valueAbovePrecisionIsNotTransformed() {
+		ValueTransformer transformer = new CPrecisionValueTransformer();
+		Object transformed = transformer.apply(10);
+
+		assertThat(transformed).isEqualTo(10);
+	}
+
+	@Test
+	public void negativeValueAbovePrecisionIsNotTransformed() {
+		ValueTransformer transformer = new CPrecisionValueTransformer();
+		Object transformed = transformer.apply(-10);
+
+		assertThat(transformed).isEqualTo(-10);
+	}
+
+	@Test
+	public void valueBelowPrecisionIsTransformedToZero() {
+		ValueTransformer transformer = new CPrecisionValueTransformer();
+		Object transformed = transformer.apply(Double.MIN_VALUE);
+
+		assertThat(transformed).isEqualTo(0);
+	}
+
+	@Test
+	public void nonNumberIsReturnedUnmodified() {
+		ValueTransformer transformer = new CPrecisionValueTransformer();
+		Object transformed = transformer.apply("my value");
+
+		assertThat(transformed).isEqualTo("my value");
+	}
+
+	@Test
+	public void nullIsReturnedUnmodified() {
+		ValueTransformer transformer = new CPrecisionValueTransformer();
+		Object transformed = transformer.apply(null);
+
+		assertThat(transformed).isNull();
+	}
+
+}


### PR DESCRIPTION
This is based on #273 and fixes #272

Here is my try at fixing your issue. Let me know if it looks good to you and I'll merge it.
